### PR TITLE
graphics/lvgl: exclude ArtInChip GE2D/MPP backend from GLOB

### DIFF
--- a/graphics/lvgl/CMakeLists.txt
+++ b/graphics/lvgl/CMakeLists.txt
@@ -68,6 +68,47 @@ if(CONFIG_GRAPHICS_LVGL)
     "${LVGL_DIR}/src/*.cpp"
     "${LVGL_DIR}/demos/*.c"
     "${LVGL_DIR}/examples/*.c")
+
+  # GLOB_RECURSE above blindly pulls every source file under src/, including
+  # hardware-accelerated draw backends and arch-specific asm that only build on
+  # specific platforms. Filter them out when the corresponding Kconfig option is
+  # not set, so unrelated targets don't try to compile them.
+
+  # blend/neon/*.S is ARMv7 (AArch32) inline asm and only assembles under an ARM
+  # 32-bit / M-profile / R-profile toolchain.
+  if(NOT CONFIG_ARCH_ARMV7A
+     AND NOT CONFIG_ARCH_ARMV7M
+     AND NOT CONFIG_ARCH_ARMV8M
+     AND NOT CONFIG_ARCH_ARMV7R
+     AND NOT CONFIG_ARCH_ARMV8R)
+    list(FILTER SRCS EXCLUDE REGEX "/blend/neon/.*\\.S$")
+  endif()
+
+  # Allwinner G2D backend; needs g2d_driver.h and hal_cache.h from the Allwinner
+  # BSP, absent on non-Allwinner targets.
+  if(NOT CONFIG_LV_USE_DRAW_G2D)
+    list(FILTER SRCS EXCLUDE REGEX "/draw/sunxi_g2d/.*\\.(c|cpp)$")
+  endif()
+
+  # VeriSilicon VG-Lite backend.
+  if(NOT CONFIG_LV_USE_DRAW_VG_LITE)
+    list(FILTER SRCS EXCLUDE REGEX "/draw/vg_lite/.*\\.(c|cpp)$")
+    list(FILTER SRCS EXCLUDE REGEX
+         "/draw/vg_lite_vector_optimize/.*\\.(c|cpp)$")
+  endif()
+
+  # NXP i.MX RT VG-Lite / PXP backends.
+  if(NOT CONFIG_LV_USE_DRAW_VGLITE)
+    list(FILTER SRCS EXCLUDE REGEX "/draw/nxp/vglite/.*\\.(c|cpp)$")
+    list(FILTER SRCS EXCLUDE REGEX "/draw/nxp/pxp/.*\\.(c|cpp)$")
+  endif()
+
+  # ArtInChip GE2D/MPP backend; needs mpp_ge.h from vendor/artinchip BSP, absent
+  # on non-ArtInChip targets.
+  if(NOT CONFIG_LV_USE_DRAW_GE2D AND NOT CONFIG_LV_USE_MPP_DEC)
+    list(FILTER SRCS EXCLUDE REGEX "/draw/artinchip/.*\\.(c|cpp)$")
+  endif()
+
   nuttx_add_library(lvgl)
 
   target_sources(lvgl PRIVATE ${SRCS})


### PR DESCRIPTION
## Summary

The LVGL `CMakeLists.txt` uses `GLOB_RECURSE` to collect all source files under `src/`, which unconditionally picks up every hardware-accelerated draw backend. This PR adds filters to exclude platform-specific backends when the corresponding Kconfig option is not enabled.

Concretely, this fixes build failures on non-ArtInChip targets:

```
apps/graphics/lvgl/lvgl/src/draw/artinchip/ge2d/lv_draw_ge2d.h:17:10:
fatal error: mpp_ge.h: No such file or directory
```

The ArtInChip GE2D/MPP backend under `src/draw/artinchip/` `#include "mpp_ge.h"` which only exists in `vendor/artinchip`. On qemu, goldfish, sim, STM32, etc. the build fails because this header is not in the include path.

This PR also cherry-picks commit `6717f02d2` from `dev-ai-contest-2026` which added the same filters for sunxi_g2d, vg_lite, and nxp backends (these filters were missing on trunk).

## What changed

Added 5 filter blocks in `apps/graphics/lvgl/CMakeLists.txt` after the `GLOB_RECURSE`:

1. `blend/neon/*.S` -- ARMv7 asm, only assembles on ARM 32-bit
2. `draw/sunxi_g2d/*.c` -- needs Allwinner BSP headers (from `6717f02d2`)
3. `draw/vg_lite/*.c` -- needs VeriSilicon BSP headers (from `6717f02d2`)
4. `draw/nxp/vglite/*.c` + `draw/nxp/pxp/*.c` -- needs NXP BSP headers (from `6717f02d2`)
5. `draw/artinchip/*.c` -- needs `mpp_ge.h` from ArtInChip BSP (**new in this PR**)

## Impact

* **Is new feature added?** No -- purely a build fix.
* **Impact on user?** No -- existing boards are unaffected.
* **Impact on build?** Fixes non-ArtInChip builds that enable `CONFIG_GRAPHICS_LVGL`. ArtInChip boards with `CONFIG_LV_USE_DRAW_GE2D` or `CONFIG_LV_USE_MPP_DEC` are not affected (the filter only excludes when neither option is set).
* **Impact on hardware?** No.
* **Impact on security?** No.
* **Impact on compatibility?** No -- additive only.

## Testing

Verified on local build (Ubuntu 22.04, arm-none-eabi-gcc 13.4.0):

### bk7236n (non-ArtInChip LVGL, no GE2D)

```
$ ./build.sh vendor/beken/boards/bk7236n/bk7236n-evb/configs/nsh --cmake
[1440/1440] Running utility command for nuttx_post_build
#### build completed successfully (21 seconds) ####
```

### qemu-arm64-v8a-ap (was failing before this fix)

```
$ ./build.sh vendor/openvela/boards/vela/configs/qemu-arm64-v8a-ap --cmake
[2936/2936] cd ... && cp nuttx vela_ap.elf && cp nuttx vela_ap.bin
#### build completed successfully (01:56 (mm:ss)) ####
```

### ArtInChip file exclusion verified

No `artinchip` `.o` files in qemu build output -- the filter correctly excludes all 9 `.c` files under `src/draw/artinchip/`.