### PR TITLE
graphics/lvgl: link SiFli EPIC HAL

### DIFF
--- a/graphics/lvgl/CMakeLists.txt
+++ b/graphics/lvgl/CMakeLists.txt
@@ -150,6 +150,10 @@ if(CONFIG_GRAPHICS_LVGL)
       lvgl PRIVATE ${NUTTX_APPS_DIR}/../${CONFIG_LV_DRAW_VG_LITE_INCLUDE})
   endif()
 
+  if(CONFIG_LV_USE_SIFLI_EPIC)
+    target_link_libraries(lvgl PRIVATE sifli_hal)
+  endif()
+
   if(NOT CONFIG_LV_ASSERT_HANDLER_INCLUDE STREQUAL "")
     target_compile_definitions(lvgl PRIVATE "LV_ASSERT_HANDLER=ASSERT(0)\;")
   endif()


### PR DESCRIPTION
## Summary

- link the LVGL target with `sifli_hal` when `CONFIG_LV_USE_SIFLI_EPIC` is enabled
- keep the dependency disabled for configurations that do not use the SiFli EPIC backend

## Validation

- built and flashed the SF32LB52 LCHSPI-ULP configuration on hardware
- completed `lvgldemo_benchmark` without assertion, hard fault, or display timeout

Depends-on: https://github.com/open-vela/apps_graphics_lvgl/pull/39
Depends-on: https://github.com/open-vela/vendor_sifli/pull/28

Signed-off-by: zhenpeng <zhenpengfu@sifli.com>