### PR TITLE
fix: prefix --defsym with -Wl, when LD is gcc driver (LTO)

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -137,23 +137,38 @@ ifneq ($(strip $(PROGNAME)),)
         $(if $(word $i,$(HEAPSIZE)),$(word $i,$(HEAPSIZE)),$(lastword $(HEAPSIZE)))) \
   )
 
+  # When LTO is enabled, LD is set to the compiler driver (e.g.
+  # arm-none-eabi-gcc) which does not understand the bare --defsym option.
+  # Detect whether LD is a gcc driver and prefix accordingly so that the
+  # flag is correctly forwarded to the underlying linker via -Wl,.
+  # Both ld and gcc accept the --defsym=symbol=value form; gcc needs the
+  # -Wl, prefix, bare ld does not. Multiple flags are separated by += ,
+  # which inserts a space for ld; for gcc we use a trailing comma instead.
+  ifneq ($(findstring gcc,$(notdir $(LD))),)
+    DEFSYM_FLAG = -Wl,--defsym=
+  else
+    DEFSYM_FLAG = --defsym=
+  endif
+
   ifneq ($(PRIORITY_$(REGLIST)), SCHED_PRIORITY_DEFAULT)
     ifneq ($(PRIORITY_$(REGLIST)),)
-     MODLDFLAGS += --defsym nx_priority=$(PRIORITY_$(REGLIST))
+     MODLDFLAGS += $(DEFSYM_FLAG)nx_priority=$(PRIORITY_$(REGLIST))
     endif
   endif
 
   ifneq ($(STACKSIZE_$(REGLIST)),)
-    MODLDFLAGS += --defsym nx_stacksize=$(STACKSIZE_$(REGLIST))
+    MODLDFLAGS += $(DEFSYM_FLAG)nx_stacksize=$(STACKSIZE_$(REGLIST))
   endif
 
   ifeq ($(CONFIG_SCHED_USER_IDENTITY),y)
-    MODLDFLAGS += --defsym nx_uid=$(UID_$(REGLIST)) --defsym nx_gid=$(GID_$(REGLIST)) --defsym nx_mod=$(GID_$(REGLIST))
+    MODLDFLAGS += $(DEFSYM_FLAG)nx_uid=$(UID_$(REGLIST))
+    MODLDFLAGS += $(DEFSYM_FLAG)nx_gid=$(GID_$(REGLIST))
+    MODLDFLAGS += $(DEFSYM_FLAG)nx_mod=$(GID_$(REGLIST))
   endif
 
   ifeq ($(CONFIG_MM_TASK_HEAP),y)
     ifneq ($(HEAPSIZE_$(REGLIST)),)
-      MODLDFLAGS += --defsym nx_heapsize=$(HEAPSIZE_$(REGLIST))
+      MODLDFLAGS += $(DEFSYM_FLAG)nx_heapsize=$(HEAPSIZE_$(REGLIST))
     endif
   endif
 endif


### PR DESCRIPTION
## Problem

When `CONFIG_LTO_FULL=y` is enabled, NuttX sets `LD` to the compiler driver (e.g. `arm-none-eabi-gcc`) instead of `arm-none-eabi-ld`. The bare `--defsym` option in `apps/Application.mk` is a direct `ld` option that gcc does not recognize, causing build failure:

```
arm-none-eabi-gcc: error: unrecognized command-line option '--defsym'; did you mean '--def='?
```

This blocks apps that set non-default `PRIORITY`/`STACKSIZE` (e.g. `ai_agent` with `PRIORITY=100`) from building with LTO enabled.

## Root Cause

Three conditions must be met simultaneously to trigger the error:

1. `CONFIG_LTO_FULL=y` → `LD` becomes `arm-none-eabi-gcc` (see `arch/arm/src/common/Toolchain.defs:309`, `arch/arm64/src/Toolchain.defs:283`, `arch/risc-v/src/common/Toolchain.defs:398`)
2. App sets non-default `PRIORITY`/`STACKSIZE` → triggers `Application.mk:140-158` to append `--defsym` to `MODLDFLAGS`
3. App is built as an independent ELF module (e.g. `CONFIG_MODULES=y` + `BUILD_MODULE=y`) → executes the `LD` step

## Fix

Detect whether `LD` contains `gcc` and use `-Wl,--defsym=` prefix to forward the flag to the underlying linker:

```makefile
ifneq ($(findstring gcc,$(notdir $(LD))),)
  DEFSYM_FLAG = -Wl,--defsym=
else
  DEFSYM_FLAG = --defsym=
endif
```

Both `ld` and `gcc` accept the `--defsym=symbol=value` form (GNU ld documentation, verified with `arm-none-eabi-ld --defsym=test=1` exit 0).

The original single-line `+=` with 3 `--defsym` flags (line 163) is split into 3 separate `+=` statements to avoid separator issues between the two syntaxes (`+=` inserts a space for `ld`; gcc needs comma separation within a single `-Wl,` argument).

## Impact Analysis

- **Architecture compatibility**: LTO→gcc LD switch only exists in `arm`, `arm64`, `risc-v`. All other architectures keep `ld` as LD → `findstring gcc` returns empty → walks `else` branch, identical to previous behavior.
- **No false positive**: All possible LD values checked — `arm-none-eabi-ld`, `ld.lld`, `armlink`, `cxarm` do not contain "gcc"; only `arm-none-eabi-gcc` matches.
- **Semantic equivalence**: `--defsym symbol=value` (old) → `--defsym=symbol=value` (new), both are valid GNU ld syntax.
- **Scope isolation**: `--defsym` is only used in `apps/Application.mk`, no other files need changes.

## Verification

Tested on Gemini-S1 (Allwinner R528, armv7-a) with `CONFIG_LTO_FULL=y` + `CONFIG_EXAMPLES_AI_AGENT_VELA=y`:

- Before fix: `arm-none-eabi-gcc: error: unrecognized command-line option '--defsym'` (when app built as module)
- After fix: Build succeeds, `vela.bin` (5.7M) + `nuttx.bin` (108M) generated
- LTO optimization preserved (no need to disable `CONFIG_LTO_FULL`)

## Files Changed

- `apps/Application.mk` — 4 occurrences of bare `--defsym` replaced with `$(DEFSYM_FLAG)` conditional