### PR TITLE
netutils/iperf: fix command line option handling

### DIFF
--- a/netutils/iperf/iperf_main.c
+++ b/netutils/iperf/iperf_main.c
@@ -93,9 +93,10 @@ static void iperf_showusage(FAR const char *progname)
          "  -p, --port=<port>    server port to listen on/connect to\n"
          "  -i, --interval=<interval> seconds between periodic bandwidth"
          " reports\n"
-         "  -t, --time=<time>    time in seconds to transmit for (default 10"
+         "  -t, --time=<time>    time in seconds to transmit for (default %d"
          " secs)\n"
-         "  -a, --abort          abort running iperf\n");
+         "  -a, --abort          abort running iperf\n",
+         IPERF_DEFAULT_TIME);
 }
 
 /****************************************************************************
@@ -154,9 +155,17 @@ int main(int argc, FAR char *argv[])
 
   struct option loptions[] =
   {
+    {"client", required_argument, 0, 'c'},
+    {"server", no_argument, 0, 's'},
+    {"udp", no_argument, 0, 'u'},
     {"local", optional_argument, 0, 'L'},
     {"rpmsg", required_argument, 0, 'R'},
     {"vsock", required_argument, 0, 'V'},
+    {"bind", required_argument, 0, 'B'},
+    {"port", required_argument, 0, 'p'},
+    {"interval", required_argument, 0, 'i'},
+    {"time", required_argument, 0, 't'},
+    {"abort", no_argument, 0, 'a'},
     {0, 0, 0, 0}
   };
 
@@ -173,7 +182,7 @@ int main(int argc, FAR char *argv[])
   cfg.sport = IPERF_DEFAULT_PORT;
   cfg.dport = IPERF_DEFAULT_PORT;
 
-  while ((opt = getopt_long(argc, argv, "sua:c:B:p:i:t:",
+  while ((opt = getopt_long(argc, argv, "suac:B:p:i:t:",
                             loptions, NULL)) != -1)
     {
       switch (opt)


### PR DESCRIPTION
Register the long options documented by iperf usage, make the abort short option argument-free, and derive the documented default transmit time from IPERF_DEFAULT_TIME.

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

